### PR TITLE
Correct the spelling of CocoaPods in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Download the appropriate build artifact from this repository and add it to your 
 1. Drag and drop the framework onto your project, instructing Xcode to copy items into your destination group's folder.
 2. Update your project settings to include the linker flags: `-ObjC -lz`
 3. Add the following Cocoa SDK frameworks to your project: `'CFNetwork', 'Security', 'MobileCoreServices', 'SystemConfiguration'`
-4. *LayerKit.framework only*: The dynamic framework distribution requires the configuration of additional build phases to complete installation. The steps are detailed on the [Layer Knowledge Base](https://support.layer.com/hc/en-us/articles/204256740-Can-I-use-LayerKit-without-Cocoapods-).
+4. *LayerKit.framework only*: The dynamic framework distribution requires the configuration of additional build phases to complete installation. The steps are detailed on the [Layer Knowledge Base](https://support.layer.com/hc/en-us/articles/204256740-Can-I-use-LayerKit-without-CocoaPods-).
 
 Build and run your project to verify installation was successful. Once you have completed a successful build, refer to the [Verifying LayerKit Configuration](#verifying-layerkit-configuration) section below for details on how to test your setup.
 


### PR DESCRIPTION

This pull requests corrects the spelling of **CocoaPods** 🤓
https://github.com/CocoaPods/shared_resources/tree/master/media

<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">One day I’ll make a bot that looks through the READMEs of all Pods, looks to see if it uses “Cocoapods” and PRs “CocoaPods” :D</p>&mdash; Ørta (@orta) <a href="https://twitter.com/orta/status/697374357975388160">February 10, 2016</a></blockquote>
<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>

Created with [`cocoapods-readme`](https://github.com/dkhamsing/cocoapods-readme).  
